### PR TITLE
Make this a module for go 1.11 and above.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/phayes/permbits
+
+go 1.11


### PR DESCRIPTION
The use of the GO111MODULE environment variable will be unavailable in go 1.17, requiring that this be migrated to a module. This solves that issue, setting the minimum go version for module use at 1.11.